### PR TITLE
Add react-universally to community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [React Webpack Node](https://github.com/choonkending/react-webpack-node) - Your One-Stop solution for a full-stack universal Redux from [Ken Ding](https://github.com/choonkending).
 - [React Native Calculator](https://github.com/benoitvallon/react-native-nw-react-calculator) - Mobile, desktop and website Apps with the same code from [Benoit Vallon](https://github.com/benoitvallon).
 - [React Cordova Boilerplate](https://github.com/unimonkiez/react-cordova-boilerplate) - TodoMVC example for React with Cordova from [Yuval Saraf](https://github.com/unimonkiez).
+- [React Universally](https://github.com/ctrlplusb/react-universally) - A starter kit giving you the minimum requirements for a production ready universal react application.
 
 ### Other
 


### PR DESCRIPTION
My starter kit makes use of a lot of the latest Webpack 2 features, providing a complex but minimal example of how to use Webpack to generate both node and browser bundles.  i.e. all production code passes through Webpack.
