### PR TITLE
Add svg-sprite-webpack-plugin to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Module Mapping](https://github.com/spartez/module-mapping-webpack-plugin) - Maps modules onto different files. -- *Maintainer*: `Spartez Team` [![Github][githubicon]](https://github.com/spartez) [![Twitter][twittericon]](https://twitter.com/thisisspartez)
 - [Serverless Webpack](https://github.com/elastic-coders/serverless-webpack) - Serverless plugin to bundle your lambdas. -- *Maintainer*: `Elastic Coders` [![Github][githubicon]](https://github.com/elastic-coders) [![Twitter][twittericon]](https://twitter.com/ElasticCoders)
 - [Prerender SPA](https://github.com/chrisvfritz/prerender-spa-plugin) - Framework-agnostic static site generation for SPAs. -- *Maintainer*: `Chris Fritz` [![Github][githubicon]](https://github.com/chrisvfritz) [![Twitter][twittericon]](https://twitter.com/chrisvfritz)
-- [SVG Sprite Webpack Plugin](https://github.com/TodayTix/svg-sprite-webpack-plugin) - Plugin/loader for SVG sprites and `<use>`-based icon systems. -- *Maintainer*: `Jeremy Tice` ([`TodayTix`](https://github.com/TodayTix)) [![Github][githubicon]](https://github.com/jetpacmonkey) [![Twitter][twittericon]](https://twitter.com/jetpacmonkey)
+- [SVG Sprite Webpack Plugin](https://github.com/TodayTix/svg-sprite-webpack-plugin) - Plugin for SVG sprites and icons. -- *Maintainer*: `Jeremy Tice` ([`TodayTix`](https://github.com/TodayTix)) [![Github][githubicon]](https://github.com/jetpacmonkey) [![Twitter][twittericon]](https://twitter.com/jetpacmonkey)
 
 [Back to top](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Module Mapping](https://github.com/spartez/module-mapping-webpack-plugin) - Maps modules onto different files. -- *Maintainer*: `Spartez Team` [![Github][githubicon]](https://github.com/spartez) [![Twitter][twittericon]](https://twitter.com/thisisspartez)
 - [Serverless Webpack](https://github.com/elastic-coders/serverless-webpack) - Serverless plugin to bundle your lambdas. -- *Maintainer*: `Elastic Coders` [![Github][githubicon]](https://github.com/elastic-coders) [![Twitter][twittericon]](https://twitter.com/ElasticCoders)
 - [Prerender SPA](https://github.com/chrisvfritz/prerender-spa-plugin) - Framework-agnostic static site generation for SPAs. -- *Maintainer*: `Chris Fritz` [![Github][githubicon]](https://github.com/chrisvfritz) [![Twitter][twittericon]](https://twitter.com/chrisvfritz)
+- [SVG Sprite Webpack Plugin](https://github.com/TodayTix/svg-sprite-webpack-plugin) - Plugin/loader for SVG sprites and `<use>`-based icon systems. -- *Maintainer*: `Jeremy Tice` ([`TodayTix`](https://github.com/TodayTix)) [![Github][githubicon]](https://github.com/jetpacmonkey) [![Twitter][twittericon]](https://twitter.com/jetpacmonkey)
 
 [Back to top](#table-of-contents)
 


### PR DESCRIPTION
[svg-sprite-webpack-plugin](https://github.com/TodayTix/svg-sprite-webpack-plugin) is a plugin/loader we recently open-sourced. It allows you to `import` an SVG, and extracts it into an external, cacheable sprite file, returning the full href for the `<use>` tag from the loader.

## Given:

**myIcon.svg**
```svg
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg width="10px" height="10px" viewBox="0 0 10 10" version="1.1">
  <line x1="0" y1="0" x2="10" y2="10"></line>
</svg>
```

**myReactIconThing.js**
```jsx
import React from 'react';
import myIcon from './myIcon.svg';

export default function() {
  return <svg><use href={myIcon} /></svg>;
}
```

## Renders:

(assuming the extracted icons have an md5 hash of `abcd1234`)

**In browser**
```html
<svg><use href="/static/icons-abcd1234.svg#myIcon"></use></svg>
```

**In `icons-abcd1234.svg`**
```svg
<svg xmlns="http://www.w3.org/2000/svg">
  <symbol id="myIcon" width="10px" height="10px" viewBox="0 0 10 10">
    <line x1="0" y1="0" x2="10" y2="10"></line>
  </symbol>
</svg>
```