### PR TITLE
add ceri-icon webpack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Modules CDN Webpack Plugin](https://github.com/mastilver/modules-cdn-webpack-plugin) - Dynamically load your modules from a CDN. -- *Maintainer*: `Thomas Sileghem` [![Github][githubicon]](https://github.com/mastilver)
 - [Generate package.json Plugin](https://github.com/lostpebble/generate-package-json-webpack-plugin) - Limit dependencies in a deployment `package.json` to only those that are actually being used by your bundle. -- *Maintainer*: `Paul Myburgh` [![Github][githubicon]](https://github.com/lostpebble)
 - [Progressive Web App Manifest](https://github.com/arthurbergmz/webpack-pwa-manifest) - PWA manifest manager and generator. -- *Maintainer*: `Arthur A. Bergamaschi` [![Github][githubicon]](https://github.com/arthurbergmz)
+- [Ceri-icon](https://github.com/ceri-comps/ceri-icon) - Powered by custom elements, load only what you need, svg inline icons. 
 
 [Back to top](#table-of-contents)
 


### PR DESCRIPTION
custom element based - load only what you need - svg inline icons.

supports:
(fa) Font Awesome
(ma) Google Material Design Icons 
(mdi) Material Design Icons
(oc) Octicons
(ic) Open Iconic
(gly) Glyphicons
(im) IcoMoon-free
(ra) ratchicons