### PR TITLE
add ceri-flag webpack plugin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Modules CDN Webpack Plugin](https://github.com/mastilver/modules-cdn-webpack-plugin) - Dynamically load your modules from a CDN. -- *Maintainer*: `Thomas Sileghem` [![Github][githubicon]](https://github.com/mastilver)
 - [Generate package.json Plugin](https://github.com/lostpebble/generate-package-json-webpack-plugin) - Limit dependencies in a deployment `package.json` to only those that are actually being used by your bundle. -- *Maintainer*: `Paul Myburgh` [![Github][githubicon]](https://github.com/lostpebble)
 - [Progressive Web App Manifest](https://github.com/arthurbergmz/webpack-pwa-manifest) - PWA manifest manager and generator. -- *Maintainer*: `Arthur A. Bergamaschi` [![Github][githubicon]](https://github.com/arthurbergmz)
+- [Ceri-flag](https://github.com/ceri-comps/ceri-flag) - Powered by custom elements, load only what you need, svg inline flags.
 
 [Back to top](#table-of-contents)
 


### PR DESCRIPTION
custom element based - load only what you need - svg inline flags.

supports:
(flg) flag-icon-css
(sq) 1x1 flag-icon-css