### PR TITLE
Add imagemin-webpack plugin/loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [json Loader](https://github.com/webpack/json-loader): json loader module for Webpack. -- *Maintainer*: `Webpack Team` [![Github][githubicon]](https://github.com/webpack)
 - [mermaid Loader](https://github.com/popul/mermaid-loader): [mermaid](http://knsv.github.io/mermaid/) loader module (diagrams) for Webpack. -- *Maintainer*: `Paul Musso` [![Github][githubicon]](https://github.com/popul)
 - [wasm loader](https://github.com/ballercat/wasm-loader): wasm binary loader module for Webpack. -- *Maintainer*: `Arthur Buldauskas` [![Github][githubicon]](https://github.com/wasm-loader)
+- [Imagemin Loader/Plugin](https://github.com/itgalaxy/imagemin-webpack): Image minimizing loader + plugin for webpack. -- *Maintainer*: `itgalaxy inc.` [![Github][githubicon]](https://github.com/itgalaxy)
 
 #### Component & Template
 


### PR DESCRIPTION
Much more recent than [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader) and [imagemin-webpack-plugin](https://github.com/Klathmon/imagemin-webpack-plugin) and boasts:

* Granular dependency installing (good for CI + bloat)
* Both plugin + loader to support multiple spots for using images
* Company supported vs individual