### PR TITLE
add 'amd2cmd-webpack-plugin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Generate package.json Plugin](https://github.com/lostpebble/generate-package-json-webpack-plugin) - Limit dependencies in a deployment `package.json` to only those that are actually being used by your bundle. -- *Maintainer*: `Paul Myburgh` [![Github][githubicon]](https://github.com/lostpebble)
 - [Progressive Web App Manifest](https://github.com/arthurbergmz/webpack-pwa-manifest) - PWA manifest manager and generator. -- *Maintainer*: `Arthur A. Bergamaschi` [![Github][githubicon]](https://github.com/arthurbergmz)
 - [FileManager Webpack Plugin](https://github.com/gregnb/filemanager-webpack-plugin) - Copy, move, delete files and directories before and after Webpack builds -- *Maintainer*: `Gregory Nowakowski` [![Github][githubicon]](https://github.com/gregnb)
-
+- [AMD2CMD Webpack Plugin](https://github.com/JunreyCen/amd2cmd-webpack-plugin) - Transform the output library exposed as an AMD module into CMD module -- *Maintainer*: `Junrey Cen` [![Github][githubicon]](https://github.com/JunreyCen)
 
 
 


### PR DESCRIPTION
Transform the output library exposed as an AMD module into CMD module.

https://github.com/JunreyCen/amd2cmd-webpack-plugin