### PR TITLE
Add shell loader to list of utility loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Icon Font Loader](https://www.npmjs.com/package/icons-loader) - Generates an iconfont from SVG dependencies.  -- *Maintainer*: `Mike Vercoelen` [![Github][githubicon]](https://github.com/mikevercoelen)
 - [Modernizr Loader](https://www.npmjs.com/package/modernizr-loader) - Get your modernizr build bundled with webpack. -- *Maintainer*: `Peerigon Devs` [![Github][githubicon]](https://github.com/peerigon)
 - [ngRouter Loader](https://github.com/shlomiassaf/ng-router-loader) - AOT capable NgModule lazy loading using angular router -- *Maintainer*: `Shlomi Assaf` [![Github][githubicon]](https://github.com/shlomiassaf) [![Twitter][twittericon]](https://twitter.com/shlomiassaf)
-- [Shell Loader](https://github.com/localjo/shell-loader) - Run arbitrary shell scripts on files. Useful as a shim for preprocessors that don't have dedicated loaders
+- [Shell Loader](https://github.com/localjo/shell-loader) - Run arbitrary shell scripts on files. Useful as a shim for preprocessors that don't have dedicated loaders.
 -- *Maintainer*: `Jo Sprague` [![Github][githubicon]](https://github.com/localjo)
 
 #### Testing

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Icon Font Loader](https://www.npmjs.com/package/icons-loader) - Generates an iconfont from SVG dependencies.  -- *Maintainer*: `Mike Vercoelen` [![Github][githubicon]](https://github.com/mikevercoelen)
 - [Modernizr Loader](https://www.npmjs.com/package/modernizr-loader) - Get your modernizr build bundled with webpack. -- *Maintainer*: `Peerigon Devs` [![Github][githubicon]](https://github.com/peerigon)
 - [ngRouter Loader](https://github.com/shlomiassaf/ng-router-loader) - AOT capable NgModule lazy loading using angular router -- *Maintainer*: `Shlomi Assaf` [![Github][githubicon]](https://github.com/shlomiassaf) [![Twitter][twittericon]](https://twitter.com/shlomiassaf)
+- [Shell Loader](https://github.com/localjo/shell-loader) - Run arbitrary shell scripts on files. Useful as a shim for preprocessors that don't have dedicated loaders
+-- *Maintainer*: `Jo Sprague` [![Github][githubicon]](https://github.com/localjo)
 
 #### Testing
 


### PR DESCRIPTION
Adds [`shell-loader`](https://github.com/localjo/shell-loader) to the list of utility loaders. This loader allows you to run arbitrary shell scripts on files. It's useful as a shim for preprocessors that don't have dedicated loaders.