### PR TITLE
Add HTML Stats Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Neutrino](https://github.com/mozilla-neutrino/neutrino-dev): Combines the power of Webpack with the simplicity of presets. -- *Maintainer*: `Eli Perelman` [![Github][githubicon]](https://github.com/eliperelman)
 - [Webpack Chain](https://github.com/mozilla-neutrino/webpack-chain): A chaining API to generate and simplify the mod. of Webpack 2 configurations. -- *Maintainer*: `Eli Perelman` [![Github][githubicon]](https://github.com/eliperelman)
 - [Speed Measure Plugin](https://github.com/stephencookdev/speed-measure-webpack-plugin) - Measures the speed of your webpack plugins and loaders.  -- *Maintainer*: `Stephen Cook` [![Github][githubicon]](https://github.com/stephencookdev)
+- [HTML Stats Plugin](https://github.com/webberig/webpack-html-stats-plugin) - Generates a static HTML report of your bundle.  -- *Maintainer*: `Mathieu Maes` [![Github][githubicon]](https://github.com/webberig)
 
 
 [Back to top](#table-of-contents)


### PR DESCRIPTION
Add HTML Stats Plugin - this plugin generates a static HTML report of your bundle, similar to webpack analyse but without having to fetch your stats json after every build (which is why this plugin is awesome :-))