### PR TITLE
doc: Add BundleStats to Webpack Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [Webpack Chain](https://github.com/mozilla-neutrino/webpack-chain): A chaining API to generate and simplify the mod. of Webpack 2 configurations. -- *Maintainer*: `Eli Perelman` [![Github][githubicon]](https://github.com/eliperelman)
 - [Speed Measure Plugin](https://github.com/stephencookdev/speed-measure-webpack-plugin) - Measures the speed of your webpack plugins and loaders.  -- *Maintainer*: `Stephen Cook` [![Github][githubicon]](https://github.com/stephencookdev)
 - [packtracker.io](https://packtracker.io/?utm_source=github&utm_medium=awesome-webpack&utm_campaign=social) - Webpack bundle analysis on every commit, report webpack stats to every pull request.
+- [BundleStats](https://github.com/bundle-stats/bundle-stats) - Generates bundle report(sizes, assets, modules) and compares the results between different builds. -- *Maintainer*: `Vio` [![Github][githubicon]](https://github.com/vio) [![Twitter][twittericon]](https://twitter.com/vio)
 
 
 [Back to top](#table-of-contents)


### PR DESCRIPTION
Webpack plugin / CLI that generates a bundle report and compares the results between different builds:

![screenshot](https://camo.githubusercontent.com/fc18c7594187a7d19adfe50a624951461b80e6ae/68747470733a2f2f7777772e64726f70626f782e636f6d2f732f767a796c78677431657237797a6c352f7765627061636b2d62756e646c652d73746174732d73637265656e73686f742e76362e6a70673f7261773d31)

https://github.com/bundle-stats/bundle-stats