### PR TITLE
adding auto-ngtemplate-loader to the list of template loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Polymer Loader](https://github.com/webpack-contrib/polymer-webpack-loader) - Loader for Polymer elements. -- *Maintainers*: `Rob Dodson` [![Github][githubicon]](https://github.com/robdodson) - `Chad Killingsworth` [![Github][githubicon]](https://github.com/ChadKillingsworth) - `Bryan Coulter` [![Github][githubicon]](https://github.com/bryandcoulter)
 - [Tag Loader](https://github.com/riot/tag-loader) - Loader for Riot tag files. -- *Maintainer*: `Riot Team` [![Github][githubicon]](https://github.com/riot) [![Twitter][twittericon]](https://twitter.com/riotjs_)
 - [Twig Loader](https://github.com/zimmo-be/twig-loader) - Twig template loader. -- *Maintainer*: `Zimmo.be Team` [![Github][githubicon]](https://github.com/zimmo-be)
+- [Auto ngTemplate Loader](https://github.com/YashdalfTheGray/auto-ngtemplate-loader): Autodetect Angular 1 templates and load them. -- *Maintainer*: `Yash Kulshrestha` [![Github][githubicon]](https://github.com/YashdalfTheGray)
 
 #### Styles
 


### PR DESCRIPTION
## Contribution checklist

- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] Suggested packages should be tested and documented.
  - [Usage](https://github.com/YashdalfTheGray/auto-ngtemplate-loader#usage)
  - [CI Build with tests](https://travis-ci.org/YashdalfTheGray/auto-ngtemplate-loader)
- [x] The pull request should have a meaningful title and include a link to the package / resource and why it's awesome.
  - [Github link to package](https://github.com/YashdalfTheGray/auto-ngtemplate-loader)
  - [NPM link to package](https://www.npmjs.com/package/auto-ngtemplate-loader)
  - This loader autodetects when a `templateUrl` is mentioned in an AngularJS 1.x file and automatically wires up the template loading using `ngtemplate-loader` and `html-loader`. This removes having to refactor AngularJS 1.x code to onboard with Webpack. 
- [x] Make an individual pull request for each suggestion.
- [x] Use the following format: `[resource](link) [ ] Description.`
- [x] Additions should be added to the bottom of the relevant category.
- [x] Link to the GitHub repo, not npmjs.com.
- [x] Keep descriptions short and simple, but descriptive.
- [x] Don't mention `Webpack` in the description as it's implied.
- [x] Start the description with a capital and end with a full stop/period.
- [x] Check your spelling and grammar.
- [x] Make sure your text editor is set to remove trailing whitespace.