### PR TITLE
Add remove-files-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [Stylelint Webpack Plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin): A Stylelint plugin for webpack. -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
 - [ESLint Webpack Plugin](https://github.com/webpack-contrib/eslint-webpack-plugin): A ESLint plugin for webpack
 . -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
+- [Remove Files Webpack Plugin](https://github.com/Amaimersion/remove-files-webpack-plugin): Flexible plugin that removes files and folders before and after compilation. -- *Maintainer*: `Sergey Kuznetsov` [![Github][githubicon]](https://github.com/Amaimersion)
 
 [Back to top](#contents)
 


### PR DESCRIPTION
[remove-files-webpack-plugin](https://github.com/Amaimersion/remove-files-webpack-plugin) is a flexible plugin that removes files and folders before and after compilation.

## Features

- removing before and after compilation ("watch" mode is supported).
- removing in trash.
- removing outside the root.
- before removing folders and files are checked for safety (i.e. if removing of folder/file is unsafe, then it will be not removed).
- emulating of remove process.
- flexible test system.
- customizable log system.
- pretty output.

## Examples

```javascript
new RemovePlugin({
    /**
     * Before compilation permanently removes
     * entire `./dist` folder.
     */
    before: {
        include: [
            './dist'
        ]
    }
})
```

```javascript
new RemovePlugin({
    /**
     * After compilation removes in trash
     * all maps files in `./dist/styles` folder and 
     * all subfolders (e.g. `./dist/styles/header`).
     */
    after: {
        test: [
            {
                folder: 'dist/styles',
                method: (absoluteItemPath) => {
                    return new RegExp(/\.map$/, 'm').test(absoluteItemPath);
                },
                recursive: true
            }
        ],
        trash: true
    }
})
```

## Pretty output

![remove-files-webpack-plugin](https://user-images.githubusercontent.com/20613502/75376960-f89ac580-58e1-11ea-9737-4b80a4fce57b.jpg)


Please see [source readme](https://github.com/Amaimersion/remove-files-webpack-plugin/blob/master/README.md) for detailed description and examples.