### PR TITLE
Add `stylus-native-loader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Isomorphic Style Loader](https://github.com/kriasoft/isomorphic-style-loader): Isomorphic CSS style loader for Webpack. -- *Maintainer*: `Kriasoft Team` [![Github][githubicon]](https://github.com/kriasoft) [![Twitter][twittericon]](https://twitter.com/kriasoft)
 - [Minify CSS-in-JS Loader](https://github.com/zaaack/minify-cssinjs-loader): RegExp-based minify CSS-in-JS loader for Webpack, don't need babel. -- *Maintainer*: `Zack Young` [![Github][githubicon]](https://github.com/zaaack) [![Twitter][twittericon]](https://twitter.com/ZaaackYoung)
 - [SASS Resources Loader](https://github.com/shakacode/sass-resources-loader): Globally import SASS resources (variables, mixins, etc.). -- *Maintainer*: `ShakaCode` [![Github][githubicon]](https://github.com/shakacode) [![Twitter][twittericon]](https://twitter.com/shakacode)
+- [Stylus Native Loader](https://github.com/slightlyfaulty/stylus-native-loader): A fast, light-weight alternative Stylus loader. -- *Maintainer*: `Saul Fautley` [![Github][githubicon]](https://github.com/slightlyfaulty)
 
 #### Language & Framework
 


### PR DESCRIPTION
[stylus-native-loader](https://github.com/slightlyfaulty/stylus-native-loader) is awesome because it solves [many issues](https://github.com/shama/stylus-loader/issues) with the original `stylus-loader` and boasts [faster build times](https://github.com/slightlyfaulty/stylus-native-loader#benchmarks).

`stylus-loader` has not been updated in over 2 years, so it's unlikely the plethora of outstanding issues will be fixed any time soon. A viable alternative is much needed for the die-hard Stylus community.