### PR TITLE
Add JetBrains/svg-sprite-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Image Loader](https://github.com/thetalecrafter/img-loader): Image minimizing loader for webpack. -- *Maintainer*: `Andy VanWagoner` [![Github][githubicon]](https://github.com/thetalecrafter) [![Twitter][twittericon]](https://twitter.com/thetalecrafter)
 - [Responsive Loader](https://github.com/herrstucki/responsive-loader): Loader for responsive images. -- *Maintainer*: `Jeremy Stucki` [![Github][githubicon]](https://github.com/herrstucki)
 - [SVG Url Loader](https://github.com/bhovhannes/svg-url-loader): Loader which loads SVG file as utf-8 encoded Url. -- *Maintainer*: `Hovhannes Babayan` [![Github][githubicon]](https://github.com/bhovhannes)
+- [SVG Sprite Loader](https://github.com/JetBrains/svg-sprite-loader): Webpack loader for creating SVG sprites. -- *Maintainer*: `JetBrains` [![Github][githubicon]](https://github.com/JetBrains)
 - [json5 Loader](https://github.com/webpack/json5-loader): json5 loader module for Webpack. -- *Maintainer*: `Webpack Team` [![Github][githubicon]](https://github.com/webpack)
 - [json Loader](https://github.com/webpack/json-loader): json loader module for Webpack. -- *Maintainer*: `Webpack Team` [![Github][githubicon]](https://github.com/webpack)
 - [mermaid Loader](https://github.com/popul/mermaid-loader): [mermaid](http://knsv.github.io/mermaid/) loader module (diagrams) for Webpack. -- *Maintainer*: `Paul Musso` [![Github][githubicon]](https://github.com/popul)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Image Loader](https://github.com/thetalecrafter/img-loader): Image minimizing loader for webpack. -- *Maintainer*: `Andy VanWagoner` [![Github][githubicon]](https://github.com/thetalecrafter) [![Twitter][twittericon]](https://twitter.com/thetalecrafter)
 - [Responsive Loader](https://github.com/herrstucki/responsive-loader): Loader for responsive images. -- *Maintainer*: `Jeremy Stucki` [![Github][githubicon]](https://github.com/herrstucki)
 - [SVG Url Loader](https://github.com/bhovhannes/svg-url-loader): Loader which loads SVG file as utf-8 encoded Url. -- *Maintainer*: `Hovhannes Babayan` [![Github][githubicon]](https://github.com/bhovhannes)
-- [SVG Sprite Loader](https://github.com/JetBrains/svg-sprite-loader): Webpack loader for creating SVG sprites. -- *Maintainer*: `JetBrains` [![Github][githubicon]](https://github.com/JetBrains)
+- [SVG Sprite Loader](https://github.com/JetBrains/svg-sprite-loader): Loader for creating SVG sprites. -- *Maintainer*: `JetBrains` [![Github][githubicon]](https://github.com/JetBrains)
 - [json5 Loader](https://github.com/webpack/json5-loader): json5 loader module for Webpack. -- *Maintainer*: `Webpack Team` [![Github][githubicon]](https://github.com/webpack)
 - [json Loader](https://github.com/webpack/json-loader): json loader module for Webpack. -- *Maintainer*: `Webpack Team` [![Github][githubicon]](https://github.com/webpack)
 - [mermaid Loader](https://github.com/popul/mermaid-loader): [mermaid](http://knsv.github.io/mermaid/) loader module (diagrams) for Webpack. -- *Maintainer*: `Paul Musso` [![Github][githubicon]](https://github.com/popul)


### PR DESCRIPTION
[SVG Sprite Loader](https://github.com/JetBrains/svg-sprite-loader)

Hello. I was using this plugin for some time and it's seems to be useful and handy. 
I use it in that way:

```js
import React from 'react';

const svgModules = require.context('Images/sprite', false, /\.svg$/);

svgModules.keys().forEach(svgModules);

const Icon = function ({ name, ...rest }) {
  return (
    <svg {...rest}>
      <use xlinkHref={ `#${ name }` } />
    </svg>
  );
};
```