### PR TITLE
Add webpack-dev-server-firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [packtracker.io](https://packtracker.io/?utm_source=github&utm_medium=awesome-webpack&utm_campaign=social) - Webpack bundle analysis on every commit, report webpack stats to every pull request.
 - [BundleStats](https://github.com/bundle-stats/bundle-stats) - Generates bundle report(sizes, assets, modules) and compares the results between different builds. -- *Maintainer*: `Vio` [![Github][githubicon]](https://github.com/vio) [![Twitter][twittericon]](https://twitter.com/vio)  
 - [Webpack Landing Generator](https://github.com/kuncevic/webpack-landing-generator): Easy way to create landing page that converts. -- *Maintainer*: `Aliaksei Kuncevic` [![Github][githubicon]](https://github.com/kuncevic) [![Twitter][twittericon]](https://twitter.com/kuncevic)
+- [Webpack Dev Server Firewall](https://github.com/funbox/webpack-dev-server-firewall): Prevents access to dev server from unknown IPs. -- *Maintainer*: `Igor Adamenko` [![Github][githubicon]](https://github.com/igoradamenko) [![Twitter][twittericon]](https://twitter.com/igoradamenko)
 
 [Back to top](#contents)
 


### PR DESCRIPTION
Hello!

We've created the package a year ago and used it in the company for tens of our projects. So, we've open sourced it and decided to add it to the list because as we think it's quite useful.

The package prevents uncontrollable access to dev server by asking manual approve from the developer when someone connects to the server from unknown IP.

More details in the repo: https://github.com/funbox/webpack-dev-server-firewall

A small article with an explanation: https://dev.to/igoradamenko/protect-your-dev-server-gob