### PR TITLE
Add Webpack Get Files Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [Stylelint Webpack Plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin): A Stylelint plugin for webpack. -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
 - [ESLint Webpack Plugin](https://github.com/webpack-contrib/eslint-webpack-plugin): A ESLint plugin for webpack
 . -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
+- [Webpack Get Files Plugin](https://github.com/mhm13dev/webpack-get-files-plugin): Plugin for extracting output assets filenames into a separate JSON file according to the entrypoints specified in the webpack configuration. -- *Maintainer*: `Mubashir Hassan` [![Github][githubicon]](https://github.com/mhm13dev) [![Twitter][twittericon]](https://twitter.com/mhm13_dev)
 
 [Back to top](#contents)
 


### PR DESCRIPTION
It is a plugin for extracting output assets filenames into a separate JSON file according to the `Entrypoints` specified in the webpack configuration.

The main purpose of this plugin is that I had a project structure where I was working with NodeJS, Express, Pug (view engine) and webpack. So basically, webpack was building my assets with names having random content hashes like `index.d53b3te33yi3y.js` and it was difficult for me to inject those assets into my views e.g. `index.pug`. That's why I came up with `webpack-get-files-plugin` that extracts the filenames of the output assets into a `GetFiles.json` file and I can easily inject them into my views.

For more details there is a README: [webpack-get-files-plugin](https://github.com/mhm13dev/webpack-get-files-plugin)