### PR TITLE
Add Webpack Extrenal Import Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [Shell Script Webpack Plugin](https://github.com/drewloomer/hook-shell-script-webpack-plugin) - A plugin for running arbitrary shell scripts when [compiler hooks](https://webpack.js.org/api/compiler-hooks/) are triggered. -- *Maintainer* `Drew Loomer` [![Github][githubicon]](https://github.com/drewloomer) [![Twitter][twittericon]](https://twitter.com/drewloomer)
 - [Stylelint Webpack Plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin): A Stylelint plugin for webpack. -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
 - [ESLint Webpack Plugin](https://github.com/webpack-contrib/eslint-webpack-plugin): A ESLint plugin for webpack
+- [Webpack External Import](https://github.com/ScriptedAlchemy/webpack-external-import): Let's you import() other modules from third parties, or other webpack builds themselves while sharing dependencies! At runtime! 
 . -- *Maintainer*: `Ricardo Gobbo de Souza` [![Github][githubicon]](https://github.com/ricardogobbosouza)
 
 [Back to top](#contents)


### PR DESCRIPTION
What is the use of webpack-external-import ?

**Load components over the wire** - Pull in components at runtime.

**Build leaner micro-frontends (MFE)** - Micro-frontends can share bundle chunks and resources with each other while remaining self-contained, removing needless code duplication.

**Split a large, multi-team app into separate deployable chunks while keeping it as one SPA -** Large apps can be split into separate feature bundles that can be deployed independently, reducing deployment bottlenecks.

**Manage common js/vendor files automatically.** - Instead of dealing with peer dependencies, externals, or anything else, you can load the dependency from a remote source.

**LOSA Style frontend architecture -** Run multiple apps on a single page.

**FOSA Style frontend orchestration -** Powerful frontend orchestration, self-organizing application architecture. Many builds act as one.