### PR TITLE
docs: add bytenode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Lightweight CSS extraction plugin -- *Maintainer*: `Webpack Contrib` [![Github][
 - [Webpack Shell Plugin Next](https://github.com/s00d/webpack-shell-plugin-next): A plugin allows you to run any shell commands before or after webpack builds. -- *Maintainer*: `Kuzmin Pavel` [![Github][githubicon]](https://github.com/s00d)
 - [Gettext Webpack Plugin](https://github.com/juanluispaz/gettext-webpack-plugin): Embed localization into your bundle using gettext. -- *Maintainer*: `Juan Luis Paz` [![Github][githubicon]](https://github.com/juanluispaz)
 - [Node Polyfill Plugin](https://github.com/Richienb/node-polyfill-webpack-plugin): Polyfill Node.js core modules. -- *Maintainer*: `Richie Bendall` [![Github][githubicon]](https://github.com/Richienb) [![Twitter][twittericon]](https://twitter.com/Richienb2)
+- [Bytenode Plugin](https://github.com/herberttn/bytenode-webpack-plugin): Compile JavaScript into bytecode using bytenode. -- *Maintainer*: `Herbert Treis Neto` [![Github][githubicon]](https://github.com/herberttn)
 
 [Back to top](#contents)
 


### PR DESCRIPTION
Adds [`bytenode-webpack-plugin`](https://github.com/herberttn/bytenode-webpack-plugin), which compiles JavaScript into low level bytecode for Node.js using [`bytenode`](https://github.com/bytenode/bytenode).